### PR TITLE
importing Mapping from collections.abc

### DIFF
--- a/src/pugnlp/util.py
+++ b/src/pugnlp/util.py
@@ -44,7 +44,8 @@ import csv
 import logging
 import warnings
 from traceback import print_exc
-from collections import OrderedDict, Mapping, Counter
+from collections import OrderedDict, Counter
+from collections.abc import Mapping
 from itertools import islice
 from decimal import Decimal, InvalidOperation, InvalidContext
 import math


### PR DESCRIPTION
Since 3.3, Mapping cannot be imported directly from collections anymore. Instead, it has to be imported from [collections.abc](https://docs.python.org/3/library/collections.abc.html). 

This pull request also tries to solve the problem reported in [issue 46 at nlpia](https://github.com/totalgood/nlpia/issues/46) 